### PR TITLE
Fix backwards compatibility

### DIFF
--- a/src/lib/BaseStub.php
+++ b/src/lib/BaseStub.php
@@ -43,7 +43,14 @@ class BaseStub
      */
     public function __construct($hostname, $opts, $channel = null)
     {
-        if (!ChannelCredentials::isDefaultRootsPemSet()) {
+        if (!method_exists('ChannelCredentials', 'isDefaultRootsPemSet')) {
+            // for backwards compatibility
+            // isDefaultRootsPemSet() may not be defined if the pecl extension
+            // is not upgraded
+            $ssl_roots = file_get_contents(
+                dirname(__FILE__).'/../../etc/roots.pem'
+            );
+        } elseif (!ChannelCredentials::isDefaultRootsPemSet()) {
             $ssl_roots = file_get_contents(
                 dirname(__FILE__).'/../../etc/roots.pem'
             );


### PR DESCRIPTION
An additional fix for 1.26: to not require pecl extension 1.26 to be installed, we should check whether the method `isDefaultRootsPemSet` is defined first. 