### PR TITLE
Bump version to 1.56.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["rpc"],
   "homepage": "https://grpc.io",
   "license": "Apache-2.0",
-  "version": "1.53.0",
+  "version": "1.56.1",
   "require": {
     "php": ">=7.0.0"
   },


### PR DESCRIPTION
Bumping to latest version because some changes released in 1.54.0 have not been released as a php package yet.

See https://github.com/grpc/grpc/releases/tag/v1.54.0