### PR TITLE
Use grpc release 1.57.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["rpc"],
   "homepage": "https://grpc.io",
   "license": "Apache-2.0",
-  "version": "1.53.0",
+  "version": "1.57.0",
   "require": {
     "php": ">=7.0.0"
   },


### PR DESCRIPTION
Let's bump up to resolve deprecation warning + addtional ug fixes
```
Deprecated: Creation of dynamic property Grpc\Call::$channel is deprecated in .../vendor/grpc/grpc/src/lib/AbstractCall.php on line 60
```