### PR TITLE
Add compatibility for php 8.4 by removing deprecation warnings

### DIFF
--- a/src/lib/ServerCallWriter.php
+++ b/src/lib/ServerCallWriter.php
@@ -81,7 +81,7 @@ class ServerCallWriter
 
     private function addSendInitialMetadataOpIfNotSent(
         array &$batch,
-        array $initialMetadata = null
+        $initialMetadata = null
     ) {
         if (!$this->initialMetadataSent_) {
             $batch[OP_SEND_INITIAL_METADATA] = $initialMetadata ?? [];

--- a/src/lib/Status.php
+++ b/src/lib/Status.php
@@ -32,7 +32,7 @@ namespace Grpc;
  */
 class Status
 {
-    public static function status(int $code, string $details, array $metadata = null): array
+    public static function status(int $code, string $details, $metadata = null): array
     {
         $status = [
             'code' => $code,
@@ -44,7 +44,7 @@ class Status
         return $status;
     }
 
-    public static function ok(array $metadata = null): array
+    public static function ok($metadata = null): array
     {
         return Status::status(STATUS_OK, 'OK', $metadata);
     }


### PR DESCRIPTION
## Feature or problem being solved
Adding explicit nullable to parameters since implicit nullable parameters are deprecated in PHP 8.4

Affected code: 

Status::L35
Satus::L47
ServerCallWrite::L94

### Further details
Adding the explicit nullable parameter, gets rid of unnecessary deprecation warnings for php 8.4, however since we need to support php 7 we need to remove the type hinting, since php 7 does not support this feature.

## Links / references
Implicitly nullable values are deprecated in php 8.4. 

See: 
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated